### PR TITLE
docs: fix typo in main index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@
    API Reference <api_reference>
 
 
-The ituitive framework for seismic data analysis and visualization in Python
+The intuitive framework for seismic data analysis and visualization in Python
 ============================================================================
 
 SeismoViz is open-source Python library designed to simplify the analysis, manipulation, and visualization of seismic catalogs. With its intuitive and efficient interface, it reduces complex workflows into just a few lines of code, empowering users to explore seismic data effortlessly.


### PR DESCRIPTION
## Summary
- Fix a typo in the main documentation index